### PR TITLE
Delimited values for flags

### DIFF
--- a/src/Clap-Core.package/ByteString.extension/instance/takeAfter..st
+++ b/src/Clap-Core.package/ByteString.extension/instance/takeAfter..st
@@ -1,0 +1,12 @@
+*Clap-Core
+takeAfter: aCharacter
+	| size res |
+	size := self size.
+	res := ''.
+	(1 to: size)
+		reverseDo: [ :n | 
+			| c |
+			c := self at: n.
+			c = aCharacter
+				ifTrue: [ ^ res ].
+			res := c asString , res ]

--- a/src/Clap-Core.package/ByteString.extension/instance/takeBefore..st
+++ b/src/Clap-Core.package/ByteString.extension/instance/takeBefore..st
@@ -1,0 +1,6 @@
+*Clap-Core
+takeBefore: aCharacter
+	| res |
+	res := ''.
+	self do: [ :c | c = aCharacter ifTrue: [ ^ res ].res := res , (c asString) ]
+	

--- a/src/Clap-Core.package/ByteString.extension/properties.json
+++ b/src/Clap-Core.package/ByteString.extension/properties.json
@@ -1,0 +1,3 @@
+{
+	"name" : "ByteString"
+}

--- a/src/Clap-Core.package/ClapFlag.class/instance/matchOn..st
+++ b/src/Clap-Core.package/ClapFlag.class/instance/matchOn..st
@@ -1,0 +1,12 @@
+matching
+matchOn: aStream
+	| arg word pos res |
+	arg := aStream peek.
+	(arg includes: $=)
+		ifFalse: [ ^ super matchOn: aStream ].
+	word := arg takeBefore: $=.
+	res := OrderedCollection new.
+	res add: word.
+	pos := $, split: (arg takeAfter: $=).
+	res addAll: pos.
+	^ super matchOn: (ClapContext on: res)

--- a/src/Clap-Core.package/ClapFlag.class/instance/matchOn..st
+++ b/src/Clap-Core.package/ClapFlag.class/instance/matchOn..st
@@ -2,6 +2,7 @@ matching
 matchOn: aStream
 	| arg word pos res |
 	arg := aStream peek.
+	arg isNil ifTrue: [ ^ self mismatch ].
 	(arg includes: $=)
 		ifFalse: [ ^ super matchOn: aStream ].
 	word := arg takeBefore: $=.

--- a/src/Clap-Tests.package/ClapCommandTest.class/instance/testMatchesWithSingleFlag.st
+++ b/src/Clap-Tests.package/ClapCommandTest.class/instance/testMatchesWithSingleFlag.st
@@ -2,13 +2,7 @@ tests
 testMatchesWithSingleFlag
 	| match |
 	subject addFlag: (ClapFlag withName: 'bar').
-	argv stub peek willReturnValueFrom: #('foo' '--bar').
-	argv stub next willReturnValueFrom: #('foo' '--bar').
-	argv stub atEnd willReturn: true.
-	argv stub atEnd
-		willReturn: false;
-		use: 1.
+	argv := ClapContext on: #('foo' '--bar').
 	match := subject matchOn: argv.
-	argv should receive next twice.
 	match should not be isMismatch.
 	match should be includesKey: 'bar'

--- a/src/Clap-Tests.package/ClapFlagTest.class/instance/testMatchesDelimitedValues.st
+++ b/src/Clap-Tests.package/ClapFlagTest.class/instance/testMatchesDelimitedValues.st
@@ -1,0 +1,9 @@
+tests
+testMatchesDelimitedValues
+	| match |
+	subject
+		addPositional: (ClapPositional withName: 'class');
+		addPositional: (ClapPositional withName: 'method').
+	argv := ClapContext on: #('--foo=Object,comment').
+	match := subject matchOn: argv.
+	match should not be isMismatch


### PR DESCRIPTION
Clap can recognize flags under the form '--flag=val1,val2...'