### PR TITLE
Update command for downloading pharo to include vm

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Metacello new baseline: 'Clap';
 ```shell
 git clone https://github.com/cdlm/clap-st.git
 cd clap-st
-curl get.pharo.org/alpha | bash
+curl get.pharo.org/alpha+vm | bash
 ```
 
 …and then, in the image just downloaded, open a workspace and evaluate:


### PR DESCRIPTION
`curl get.pharo.org/alpha | bash` only downloads the latest Pharo image, not the vm. PR updates README to use `curl get.pharo.org/alpha+vm | bash` in loading instructions